### PR TITLE
feat: template now uses coro

### DIFF
--- a/mac-example-bot.xcodeproj/project.pbxproj
+++ b/mac-example-bot.xcodeproj/project.pbxproj
@@ -253,10 +253,19 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = /opt/homebrew/include;
-				LIBRARY_SEARCH_PATHS = /opt/homebrew/lib;
+				HEADER_SEARCH_PATHS = (
+					/opt/homebrew/include,
+					/usr/local/include,
+				);
+				LIBRARY_SEARCH_PATHS = (
+					/opt/homebrew/lib,
+					/usr/local/lib,
+				);
 				OTHER_CFLAGS = "";
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-DDPP_CORO",
+				);
 				OTHER_LDFLAGS = "-ldpp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -272,10 +281,19 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = /opt/homebrew/include;
-				LIBRARY_SEARCH_PATHS = /opt/homebrew/lib;
+				HEADER_SEARCH_PATHS = (
+					/opt/homebrew/include,
+					/usr/local/include,
+				);
+				LIBRARY_SEARCH_PATHS = (
+					/opt/homebrew/lib,
+					/usr/local/lib,
+				);
 				OTHER_CFLAGS = "";
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-DDPP_CORO",
+				);
 				OTHER_LDFLAGS = "-ldpp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/mac-example-bot/main.cpp
+++ b/mac-example-bot/main.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <dpp/dpp.h>
-#include <dpp/json.h>
 
 /* Be sure to place your token in the line below.
  * Follow steps here to get a token:

--- a/mac-example-bot/main.cpp
+++ b/mac-example-bot/main.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <dpp/dpp.h>
+#include <dpp/json.h>
 
 /* Be sure to place your token in the line below.
  * Follow steps here to get a token:
@@ -17,11 +18,12 @@ int main() {
 	/* Output simple log messages to stdout */
 	bot.on_log(dpp::utility::cout_logger());
 
-	/* Handle slash command */
-	bot.on_slashcommand([](const dpp::slashcommand_t& event) {
+	/* Handle slash command with the most recent addition to D++ features, coroutines! */
+	bot.on_slashcommand([](const dpp::slashcommand_t& event) -> dpp::task<void> {
 		if (event.command.get_command_name() == "ping") {
-			event.reply("Pong!");
+			co_await event.co_reply("Pong!");
 		}
+		co_return;
 	});
 
 	/* Register slash command here in on_ready */


### PR DESCRIPTION
This PR makes the template now include Coro, it also makes the header and library paths look for `/usr/local/` so users can use libraries from there too.

This PR demands the new version of D++ to be released to brew (10.0.29) before this can be released.

